### PR TITLE
Align repository with DPC conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Copilot Instructions
+
+This repository follows the DPC (Dans Plugins Community) conventions defined at
+https://github.com/Dans-Plugins/dpc-conventions. Read those conventions before
+making any changes.
+
+## Technology Stack
+
+- Language: Java
+- Build tool: Maven
+- Target platform: Spigot / Paper (Minecraft plugin)
+- API version: 1.13+
+
+## Project Structure
+
+- `src/main/java/dansplugins/playerlore/` – Plugin source code
+- `src/main/java/dansplugins/playerlore/commands/` – Command handlers (AddCommand, EditCommand, RemoveCommand, HelpCommand)
+- `src/main/java/dansplugins/playerlore/services/` – ConfigService
+- `src/main/resources/` – `plugin.yml`
+
+## Coding Conventions
+
+- Commands extend `AbstractPluginCommand` from the Ponder library.
+- Config is managed through `ConfigService`.
+
+## Contribution Workflow
+
+- Branch from `main` for all changes.
+- Open a pull request against `main`.
+- Reference the related GitHub issue in every pull request description.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [ created ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package
+
+      - name: Upload JAR to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            target/*.jar
+            !target/original-*.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [1.1]
+
+### Added
+- `/pl add`, `/pl edit`, `/pl remove` commands for managing item lore
+- `/pl help` command
+- `debugMode` config option

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,10 @@
+# PlayerLore Commands
+
+All commands use `/pl` or `/playerlore` as the base. Commands require the player to be holding the item they wish to modify.
+
+| Command | Description | Permission |
+|---------|-------------|------------|
+| `/pl help` | View a list of commands. | `pl.help` |
+| `/pl add "<line of lore>"` | Add a line of lore to the held item. | `pl.add` |
+| `/pl edit <lineIndex> "<new lore>"` | Edit a line of lore on the held item (1-based index). | `pl.edit` |
+| `/pl remove <lineIndex>` | Remove a line of lore from the held item (1-based index). | `pl.remove` |

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,8 @@
+# PlayerLore Configuration
+
+The configuration file is located at `plugins/PlayerLore/config.yml`.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `version` | String | *(plugin version)* | Plugin version. Do not edit manually. |
+| `debugMode` | Boolean | `false` | Enables verbose debug logging to the console. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+## Thank You
+
+Thank you for your interest in contributing to PlayerLore! This guide will help you get started.
+
+## Links
+
+- [Website](https://dansplugins.com)
+- [Discord](https://discord.gg/xXtuAQ2)
+
+## Requirements
+
+- A GitHub account
+- Git installed on your local machine
+- A Java IDE or text editor
+- A basic understanding of Java
+
+## Getting Started
+
+1. [Sign up for GitHub](https://github.com/signup) if you don't have an account.
+2. Fork the repository by clicking **Fork** at the top right of the repo page.
+3. Clone your fork: `git clone https://github.com/<your-username>/PlayerLore.git`
+4. Open the project in your IDE.
+5. Build the plugin: `mvn clean package`
+   If you encounter errors, please open an issue.
+
+## Identifying What to Work On
+
+### Issues
+
+Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/PlayerLore/issues).
+
+### Milestones
+
+Issues are grouped into [milestones](https://github.com/Dans-Plugins/PlayerLore/milestones) representing upcoming releases.
+
+## Making Changes
+
+1. Make sure an issue exists for the work. If not, create one.
+2. Switch to `main`: `git checkout main`
+3. Create a branch: `git checkout -b <branch-name>`
+4. Make your changes.
+5. Test your changes.
+6. Commit: `git commit -m "Description of changes"`
+7. Push: `git push origin <branch-name>`
+8. Open a pull request against `main`, link the related issue with `#<number>`.
+9. Address review feedback.
+
+## Testing
+
+Run the build with:
+
+Linux / macOS:
+
+    mvn clean package
+
+Windows:
+
+    mvn clean package
+
+For manual testing, place the built JAR from `target/` into a local Spigot server's `plugins` folder and restart the server.
+
+## Questions
+
+Ask in the [Discord server](https://discord.gg/xXtuAQ2).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,33 @@
+# PlayerLore User Guide
+
+## What is PlayerLore?
+
+PlayerLore is a Spigot plugin that lets players add, edit, and remove custom lore lines on items they are holding. It is useful for roleplayers, server admins, and anyone who wants to add flavour text or descriptions to in-game items.
+
+## Installation
+
+1. Download the latest `PlayerLore-<version>.jar` from the [Releases](https://github.com/Dans-Plugins/PlayerLore/releases) page.
+2. Place the JAR in your server's `plugins/` folder.
+3. Restart the server.
+4. The plugin generates `plugins/PlayerLore/config.yml` on first run.
+
+## Getting Started
+
+1. Hold an item in your main hand.
+2. Add a lore line: `/pl add "This sword was forged in dragon fire."`
+3. View the item's tooltip — the lore line appears below the item name.
+4. Edit it: `/pl edit 1 "Forged in the fires of Mount Doom."`
+5. Remove it: `/pl remove 1`
+
+## Permissions
+
+| Permission | Default | Description |
+|------------|---------|-------------|
+| `pl.help` | `true` | View the help menu. |
+| `pl.add` | `true` | Add a lore line to a held item. |
+| `pl.edit` | `true` | Edit a lore line on a held item. |
+| `pl.remove` | `true` | Remove a lore line from a held item. |
+
+## Support
+
+Ask questions in the [Discord server](https://discord.gg/xXtuAQ2) or open a [GitHub issue](https://github.com/Dans-Plugins/PlayerLore/issues).


### PR DESCRIPTION
Brings this repository into compliance with the [DPC conventions](https://github.com/Dans-Plugins/dpc-conventions).

### New files
- `CONTRIBUTING.md` — fork/branch/PR workflow, Maven build instructions
- `USER_GUIDE.md` — installation, usage walkthrough, permissions table
- `COMMANDS.md` — `/pl help|add|edit|remove` reference
- `CONFIG.md` — version and debugMode options documented
- `CHANGELOG.md` — Keep a Changelog format seeded with 1.1
- `.github/copilot-instructions.md` — tech stack and contribution workflow
- `.github/workflows/build.yml` — CI on push/PR to `main`
- `.github/workflows/release.yml` — attaches JAR to GitHub Releases